### PR TITLE
URLの定義がダブっているの微妙そうなので、pathで作っておく

### DIFF
--- a/uploader.go
+++ b/uploader.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/mattermost/mattermost-server/v5/model"
 	"image"
 	"image/gif"
 	_ "image/gif"
@@ -18,6 +17,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/mattermost/mattermost-server/v5/model"
 )
 
 func main() {
@@ -35,17 +36,13 @@ func main() {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}
-	api, err := url.Parse("https://your-mattermost.example/api/v4")
-	if err != nil {
-		fmt.Println(err.Error())
-		os.Exit(1)
-	}
-	api.Host = u.Host
-	api.Scheme = u.Scheme
+
+	apiUrl := *u
+	apiUrl.Path = path.Join(apiUrl.Path, "api", "v4")
 
 	c := model.Client4{
 		Url:        u.String(),
-		ApiUrl:     api.String(),
+		ApiUrl:     apiUrl.String(),
 		HttpClient: &http.Client{},
 		AuthToken:  token,
 		AuthType:   model.HEADER_BEARER,


### PR DESCRIPTION
# 背景
- mattermostのAPIはmattermostのアプリケーションのエンドポイントのURLの末尾に`/api/v4`がつくのが原則
  - <https://api.mattermost.com/#tag/schema>
  - nginxでルーティングしているケースなど例外はあるかもしれないけど基本はこれだと思う
- そのためmattermostのURLを引数で貰っているので、末尾にapi/v4だけつければよさそう
  - 今は一旦URLオブジェクト作っちゃってるけど、引数を信用するなら使い回しでいいんじゃないかな
  - であればexample的なURLを指定していると、ミスってリクエスト飛びそうなので、uを完全にコピペしておきたい

# やったこと 
- `u`を値コピーして、パスだけ修正するようにしました